### PR TITLE
Wheel distribution prep — v0.3.0-tq1 (cohesive launch with vllm-turboquant)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,154 @@
+name: Build wheels
+
+# Tag-triggered cibuildwheel matrix for llama-cpp-python-turboquant.
+#
+# Trusted Publishing (PyPI) is configured against:
+#   project:  llama-cpp-python-turboquant
+#   owner:    tqcli
+#   repo:     llama-cpp-python-turboquant   (note: NOT llama-cpp-turboquant)
+#   workflow: wheels.yml
+#   environment: (none — leave blank to match the form template used in 0.B)
+#
+# The publish job uses pypa/gh-action-pypi-publish@release/v1 with NO
+# `with.password:` argument; OIDC handles auth.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+jobs:
+  build_wheels:
+    name: ${{ matrix.os }} cp${{ matrix.python }} ${{ matrix.variant }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ---------- Linux x86_64 ----------
+          - { os: ubuntu-latest,  python: "310", variant: cpu  }
+          - { os: ubuntu-latest,  python: "311", variant: cpu  }
+          - { os: ubuntu-latest,  python: "312", variant: cpu  }
+          - { os: ubuntu-latest,  python: "310", variant: cuda }
+          - { os: ubuntu-latest,  python: "311", variant: cuda }
+          - { os: ubuntu-latest,  python: "312", variant: cuda }
+          # ---------- Windows x86_64 ----------
+          - { os: windows-latest, python: "310", variant: cpu  }
+          - { os: windows-latest, python: "311", variant: cpu  }
+          - { os: windows-latest, python: "312", variant: cpu  }
+          - { os: windows-latest, python: "310", variant: cuda }
+          - { os: windows-latest, python: "311", variant: cuda }
+          - { os: windows-latest, python: "312", variant: cuda }
+          # ---------- macOS arm64 (Metal) ----------
+          - { os: macos-14, python: "310", variant: metal }
+          - { os: macos-14, python: "311", variant: metal }
+          - { os: macos-14, python: "312", variant: metal }
+          # ---------- macOS x86_64 (CPU) ----------
+          - { os: macos-13, python: "310", variant: cpu }
+          - { os: macos-13, python: "311", variant: cpu }
+          - { os: macos-13, python: "312", variant: cpu }
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up ccache (Linux/Windows)
+        if: runner.os != 'macOS'
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.os }}-cp${{ matrix.python }}-${{ matrix.variant }}
+
+      - name: Install CUDA 12.8 toolkit (Linux)
+        if: matrix.variant == 'cuda' && runner.os == 'Linux'
+        uses: Jimver/cuda-toolkit@v0.2.16
+        with:
+          cuda: "12.8.0"
+          method: "network"
+          sub-packages: '["nvcc","cudart","cublas","cublas_dev","curand","curand_dev","cusparse","cusparse_dev","cusolver","cusolver_dev"]'
+
+      - name: Install CUDA 12.8 toolkit (Windows)
+        if: matrix.variant == 'cuda' && runner.os == 'Windows'
+        uses: Jimver/cuda-toolkit@v0.2.16
+        with:
+          cuda: "12.8.0"
+          method: "network"
+
+      - name: Build wheel (cibuildwheel)
+        uses: pypa/cibuildwheel@v2.19
+        env:
+          CIBW_BUILD: "cp${{ matrix.python }}-*"
+          CIBW_SKIP: "*-musllinux* *-manylinux_i686 pp*"
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
+          CIBW_ENVIRONMENT_LINUX: >-
+            CMAKE_ARGS=${{ matrix.variant == 'cuda' && '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=80;86;89;90' || '' }}
+            MAX_JOBS=2
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            CMAKE_ARGS=${{ matrix.variant == 'cuda' && '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=80;86;89;90' || '' }}
+            MAX_JOBS=2
+          CIBW_ENVIRONMENT_MACOS: >-
+            CMAKE_ARGS=${{ matrix.variant == 'metal' && '-DGGML_METAL=on -DGGML_METAL_EMBED_LIBRARY=ON' || '' }}
+            MAX_JOBS=2
+          CIBW_BEFORE_BUILD: pip install --upgrade pip cmake ninja scikit-build-core
+          # Smoke-test the sentinel inside cibuildwheel's isolated test env.
+          CIBW_TEST_COMMAND: >-
+            python -c "import llama_cpp; assert llama_cpp.TURBOQUANT_BUILD is True, 'sentinel missing'; assert llama_cpp.TURBOQUANT_KV_TYPES == ('turbo2','turbo3','turbo4'), 'KV types wrong'; print('sentinel OK')"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-cp${{ matrix.python }}-${{ matrix.variant }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  build_sdist:
+    name: sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  github_release:
+    name: Attach wheels to GitHub Release
+    needs: [build_wheels, build_sdist]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: [build_wheels, build_sdist]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # No `with.password:` — OIDC handles auth via Trusted Publishing.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/llama.cpp"]
 	path = vendor/llama.cpp
-	url = https://github.com/ggerganov/llama.cpp.git
+	url = https://github.com/tqcli/llama-cpp-turboquant.git

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+> **TurboQuant fork notice.** This is a fork of
+> [`abetlen/llama-cpp-python`](https://github.com/abetlen/llama-cpp-python)
+> with TurboQuant KV cache compression baked into the bundled
+> [`llama.cpp`](https://github.com/ggml-org/llama.cpp) build. The Python
+> bindings layer is unchanged from upstream; the C++ vendor submodule points
+> at [`tqcli/llama-cpp-turboquant`](https://github.com/tqcli/llama-cpp-turboquant)
+> instead of `ggml-org/llama.cpp`.
+>
+> Install:
+>
+> ```bash
+> pip install llama-cpp-python-turboquant
+> ```
+>
+> The runtime sentinel `llama_cpp.TURBOQUANT_BUILD` is `True` on this fork
+> and absent on upstream — `tqcli`'s engine auditor uses this to detect
+> mismatched installs. **Not affiliated with the upstream `llama-cpp-python`
+> project.** See [NOTICE](./NOTICE) for research-attribution details
+> (TurboQuant ICLR 2026, PolarQuant AISTATS 2026, QJL AAAI 2025).
+
+---
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/abetlen/llama-cpp-python/main/docs/icon.svg" style="height: 5rem; width: 5rem">
 </p>

--- a/llama_cpp/__init__.py
+++ b/llama_cpp/__init__.py
@@ -2,3 +2,11 @@ from .llama_cpp import *
 from .llama import *
 
 __version__ = "0.3.20"
+
+# ---------------------------------------------------------------------------
+# TurboQuant runtime sentinels.
+# tqcli/core/engine_auditor.py reads TURBOQUANT_BUILD to distinguish this
+# fork from upstream llama-cpp-python at runtime.
+# ---------------------------------------------------------------------------
+TURBOQUANT_BUILD: bool = True
+TURBOQUANT_KV_TYPES: tuple[str, ...] = ("turbo2", "turbo3", "turbo4")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["scikit-build-core[pyproject]>=0.9.2"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "llama_cpp_python"
+name = "llama-cpp-python-turboquant"
 dynamic = ["version"]
 description = "Python bindings for the llama.cpp library"
 readme = "README.md"

--- a/scripts/tag_command.sh
+++ b/scripts/tag_command.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tag command for triggering the wheel publish, plus post-publish verification.
+#
+# Run AFTER:
+#  1. `tqcli/llama-cpp-python-turboquant` repo exists with Artifacts 1-4 applied.
+#  2. PyPI Pending Publisher is registered against
+#     project=llama-cpp-python-turboquant, owner=tqcli, repo=llama-cpp-python-turboquant,
+#     workflow=wheels.yml, environment=(blank).
+
+set -euo pipefail
+
+# 1. Tag and push.
+gh repo clone tqcli/llama-cpp-python-turboquant
+cd llama-cpp-python-turboquant
+git tag v0.3.0-tq1
+git push origin v0.3.0-tq1
+
+# 2. Watch the workflow run.
+gh run watch --exit-status --repo tqcli/llama-cpp-python-turboquant
+
+# 3. Verify on PyPI.
+pip index versions llama-cpp-python-turboquant
+# Expected: 0.3.0
+
+# 4. Smoke-install on a clean venv.
+python -m venv /tmp/v-llcpt
+# shellcheck disable=SC1091
+source /tmp/v-llcpt/bin/activate
+pip install llama-cpp-python-turboquant
+python -c "import llama_cpp; print(llama_cpp.TURBOQUANT_BUILD, llama_cpp.TURBOQUANT_KV_TYPES)"
+# Expected: True ('turbo2', 'turbo3', 'turbo4')
+
+# 5. (optional) Confirm the PyPI Pending Publisher auto-promoted to Active.
+bash .claude/skills/tq-pypi/scripts/check_name_available.sh llama-cpp-python-turboquant
+# Expected: TAKEN by us


### PR DESCRIPTION
## Summary

Workstream A prep for the tqCLI 0.7.0 cohesive launch. Applies all staged artifacts so the fork is ready to tag `v0.3.0-tq1`, which triggers the cibuildwheel matrix and Trusted-Publishing publish to PyPI as `llama-cpp-python-turboquant`.

DRAFT until on-hardware verification gates pass.

## What changed

- `pyproject.toml`: distribution renamed `llama_cpp_python` → `llama-cpp-python-turboquant`. Import package `llama_cpp` unchanged.
- `llama_cpp/__init__.py`: appended `TURBOQUANT_BUILD = True` + `TURBOQUANT_KV_TYPES` sentinels.
- `README.md`: prepended TurboQuant fork-notice banner.
- `.github/workflows/wheels.yml` (NEW): cibuildwheel matrix (Linux/Windows x86_64 CPU+CUDA, macOS arm64 Metal + x86_64 CPU, Python 3.10/3.11/3.12) + OIDC Trusted Publishing + GitHub Release attach + sentinel smoke test.
- `scripts/tag_command.sh` (NEW): tag + post-publish verification helper.
- `vendor/llama.cpp` submodule: repointed from `ggerganov/llama.cpp` → `tqcli/llama-cpp-turboquant @ 808ee6e` (feature/turboquant-kv-cache HEAD). Without this, the wheel would ship with vanilla llama.cpp and no TurboQuant kernels.

## Source

Staged in tqcli/tqcli @ branch `task-1-build-llama-fork-1777190345` at `patches/llama-cpp-turboquant/`. From the 2026-04-26 `/project-manager` worker-1 run.

## Test plan

- [ ] Local cibuildwheel sanity (one cell) builds an importable wheel
- [ ] Sentinel: `python -c "import llama_cpp; assert llama_cpp.TURBOQUANT_BUILD is True"`
- [ ] WSL2 + RTX A2000: install wheel, run Gemma 4 Q4_K_M with `cache_type_k="turbo3"`, verify KV compression
- [ ] After gates pass: tag `v0.3.0-tq1`