### PR TITLE
wheels.yml: fast-follow fixes for 0.3.1-tq2 (CUDA action + Windows pip + macos-13)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,10 +44,16 @@ jobs:
           - { os: macos-14, python: "310", variant: metal }
           - { os: macos-14, python: "311", variant: metal }
           - { os: macos-14, python: "312", variant: metal }
-          # ---------- macOS x86_64 (CPU) ----------
-          - { os: macos-13, python: "310", variant: cpu }
-          - { os: macos-13, python: "311", variant: cpu }
-          - { os: macos-13, python: "312", variant: cpu }
+          # ---------- macOS x86_64 (CPU) — cross-built from macos-14 (arm64) ----------
+          # Native macos-13 (Intel) runners are deprecated by GitHub (closing
+          # Dec 2025) and v0.3.0-tq1's macos-13 cells sat 24h in the queue
+          # without ever being assigned. Cross-build x86_64 wheels from arm64
+          # runners; CIBW_TEST_SKIP below skips the in-process sentinel test
+          # for the cross-arch wheel since arm64 runners can't execute x86_64
+          # binaries natively.
+          - { os: macos-14, python: "310", variant: cpu }
+          - { os: macos-14, python: "311", variant: cpu }
+          - { os: macos-14, python: "312", variant: cpu }
 
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +68,7 @@ jobs:
 
       - name: Install CUDA 12.8 toolkit (Linux)
         if: matrix.variant == 'cuda' && runner.os == 'Linux'
-        uses: Jimver/cuda-toolkit@v0.2.16
+        uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: "12.8.0"
           method: "network"
@@ -70,7 +76,7 @@ jobs:
 
       - name: Install CUDA 12.8 toolkit (Windows)
         if: matrix.variant == 'cuda' && runner.os == 'Windows'
-        uses: Jimver/cuda-toolkit@v0.2.16
+        uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: "12.8.0"
           method: "network"
@@ -82,7 +88,8 @@ jobs:
           CIBW_SKIP: "*-musllinux* *-manylinux_i686 pp*"
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
+          # variant=metal → native arm64 (macos-14); variant=cpu → cross-build x86_64 from arm64 runner.
+          CIBW_ARCHS_MACOS: ${{ matrix.variant == 'metal' && 'arm64' || 'x86_64' }}
           CIBW_ENVIRONMENT_LINUX: >-
             CMAKE_ARGS=${{ matrix.variant == 'cuda' && '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=80;86;89;90' || '' }}
             MAX_JOBS=2
@@ -92,10 +99,16 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >-
             CMAKE_ARGS=${{ matrix.variant == 'metal' && '-DGGML_METAL=on -DGGML_METAL_EMBED_LIBRARY=ON' || '' }}
             MAX_JOBS=2
-          CIBW_BEFORE_BUILD: pip install --upgrade pip cmake ninja scikit-build-core
+          # Use `python -m pip` so Windows can self-upgrade pip without the
+          # "ERROR: To modify pip, please run the following command..." abort
+          # that bit v0.3.0-tq1's Windows CPU cells.
+          CIBW_BEFORE_BUILD: python -m pip install --upgrade pip cmake ninja scikit-build-core
           # Smoke-test the sentinel inside cibuildwheel's isolated test env.
           CIBW_TEST_COMMAND: >-
             python -c "import llama_cpp; assert llama_cpp.TURBOQUANT_BUILD is True, 'sentinel missing'; assert llama_cpp.TURBOQUANT_KV_TYPES == ('turbo2','turbo3','turbo4'), 'KV types wrong'; print('sentinel OK')"
+          # arm64 runners cannot execute the x86_64 sentinel test natively;
+          # skip that test cell. The wheel is still produced and uploaded.
+          CIBW_TEST_SKIP: "*-macosx_x86_64"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Fast-follow on `v0.3.0-tq1`. The wheels.yml matrix had three independent failures that skipped the `publish` and `github_release` jobs:

| Failures | Root cause | Fix |
|---|---|---|
| 6× CUDA cells (Linux + Windows × 3 Py) | `Jimver/cuda-toolkit@v0.2.16` incompatible with CUDA 12.8 network install | Bump to `@v0.2.19` |
| 3× Windows CPU cells | `pip install --upgrade pip` aborts on Windows ("To modify pip, please run...") | Switch `CIBW_BEFORE_BUILD` to `python -m pip install --upgrade pip ...` |
| 3× macos-13 CPU cells | `runner_name: ""` for 24h — macos-13 (Intel Mac) runner pool closing Dec 2025; never assigned | Replace native macos-13 cells with cross-built x86_64 from macos-14 arm64; `CIBW_TEST_SKIP="*-macosx_x86_64"` skips the sentinel test cell on the cross-arch wheel |

After merge, tag `v0.3.1-tq2` on main → triggers `wheels.yml` → publishes via OIDC Trusted Publishing. Unblocks Track 3 (RunPod V3/V4/V5 verifies) and Track 4 (W-C pin + tqcli v0.7.0 umbrella) of the 0.7.0 launch.

Refs: tqcli/tqcli `docs/prompts/ship_turboquant_wheels.md` Section 4.6.